### PR TITLE
Change domain name of redis site

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Clone this repository into VVV's `www` directory, then reprovision VVV:
 
 ```
 $ cd path/to/vvv/www
-$ git clone https://github.com/goblindegook/VVV-Redis redis.vvv
+$ git clone https://github.com/goblindegook/VVV-Redis redis.dev
 $ vagrant provision
 ```
 
-Once installed, a web-based Redis management interface becomes available under [http://redis.vvv](http://redis.vvv) and you may begin using Redis on your local WordPress development installs through one of these plugins:
+Once installed, a web-based Redis management interface becomes available under [http://redis.dev](http://redis.dev) and you may begin using Redis on your local WordPress development installs through one of these plugins:
 
 * [WP Redis](https://wordpress.org/plugins/wp-redis/) (recommended)
 * [Redis Object Cache](https://wordpress.org/plugins/redis-object-cache/)

--- a/vvv-hosts
+++ b/vvv-hosts
@@ -1,1 +1,1 @@
-redis.vvv
+redis.dev

--- a/vvv-nginx.conf
+++ b/vvv-nginx.conf
@@ -6,7 +6,7 @@ server {
     # The domain name(s) that the site should answer
     # for. You can use a wildcard here, e.g.
     # *.example.com for a subdomain multisite.
-    server_name     redis.vvv;
+    server_name     redis.dev;
 
     # The folder containing your site files.
     # The {vvv_path_to_folder} token gets replaced


### PR DESCRIPTION
There are some issues with entering `redis.vvv` on some browsers. This way the problem is solved :)
